### PR TITLE
Suppresses `quill-finagle-mysql`'s query log (INFO level)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
 # finatra-quill-query-log-to-debug-level
 [![Build Status](https://travis-ci.org/laysakura/finatra-quill-query-log-to-debug-level.svg?branch=master)](https://travis-ci.org/laysakura/finatra-quill-query-log-to-debug-level)
 
-A simple sample project using finatra-thrift.
+Demonstrates how to supress `quill-finagle-mysql`'s noisy query log.
+
+The trick is just adding a simple setting to `logback.xml`.
+
+```xml:logback.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- Suppress INFO level log by quill-finagle-mysql -->
+  <logger name="io.getquill.FinagleMysqlContext" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
+</configuration>
+```
 
 ## Development
 

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -11,6 +11,7 @@
     <appender-ref ref="STDOUT" />
   </root>
 
+  <!-- Suppress INFO level log by quill-finagle-mysql -->
   <logger name="io.getquill.FinagleMysqlContext" level="WARN">
     <appender-ref ref="STDOUT" />
   </logger>

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -10,4 +10,8 @@
   <root level="debug">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <logger name="io.getquill.FinagleMysqlContext" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
 </configuration>


### PR DESCRIPTION
## Problem
`quill-finagle-mysql` outputs INFO level log per each query execution.

See: https://github.com/getquill/quill/blob/19010f943d44908ead5a58c91304b41df86acb97/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala#L71

## BEFORE
https://travis-ci.org/laysakura/finatra-quill-suppress-query-log/builds/200797424#L1532

```sql
===========================================================================
Server Started: verbose-service-server
===========================================================================
AdminHttp      -> http://127.0.0.1:45407/admin
ExternalThrift -> thrift://127.0.0.1:35583
04:52:19.389 [finagle/netty3-4] INFO  ClockedDrainer - Drainer is disabled; bypassing
04:52:19.620 [finagle/netty3-4] INFO  c.g.l.q.c.VerboseServiceController - info!
	you said "hi :D"
04:52:19.634 [finagle/netty3-4] INFO  io.getquill.FinagleMysqlContext - SELECT x3.id, x3.first_name, x3.last_name, x3.gender, x3.age, x3.created_at, x3.updated_at FROM user x3 WHERE x3.id = ?
04:52:19.754 [finagle/netty3-2] INFO  c.t.f.t.filters.AccessLoggingFilter - EmbeddedVerboseServiceTest 12/Feb/2017:04:52:19 +0000 'echo' 139
```

## AFTER this PR
https://travis-ci.org/laysakura/finatra-quill-suppress-query-log/builds/200808640#L887-L890

```sql
===========================================================================
Server Started: verbose-service-server
===========================================================================
AdminHttp      -> http://127.0.0.1:38567/admin
ExternalThrift -> thrift://127.0.0.1:38827
06:47:07.446 [finagle/netty3-4] INFO  ClockedDrainer - Drainer is disabled; bypassing
06:47:07.524 [finagle/netty3-4] INFO  c.g.l.q.c.VerboseServiceController - info!
	you said "hi :D"
06:47:07.563 [finagle/netty3-2] INFO  c.t.f.t.filters.AccessLoggingFilter - EmbeddedVerboseServiceTest 12/Feb/2017:06:47:07 +0000 'echo' 41
```